### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,17 @@
 <html lang="en">
 
 <head>
+    <script>
+    (function() {
+        var s = localStorage.getItem('theme');
+        if (s === 'light' || s === 'dark') {
+            document.documentElement.setAttribute('data-theme', s);
+        } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+            document.documentElement.setAttribute('data-theme', 'light');
+        }
+        document.documentElement.classList.add('no-transition');
+    })();
+    </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content="Ryan Ramboer" />
@@ -77,6 +88,10 @@
                 <li><a href="#projs">Projects</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
+            <button class="theme-toggle" aria-label="Toggle light/dark mode">
+                <i data-lucide="sun" class="theme-icon-light"></i>
+                <i data-lucide="moon" class="theme-icon-dark"></i>
+            </button>
             <div class="menu-btn" role="button" aria-label="Menu" aria-expanded="false" tabindex="0">
                 <i data-lucide="menu"></i>
             </div>

--- a/particles.js
+++ b/particles.js
@@ -3,7 +3,7 @@
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
 
-    const THEME_COLOR = '#3572ff';
+    var themeColor = document.documentElement.getAttribute('data-theme') === 'light' ? '#2558cc' : '#3572ff';
     const PARTICLE_COUNT_DESKTOP = 80;
     const PARTICLE_COUNT_MOBILE = 40;
     const CONNECTION_DISTANCE = 150;
@@ -83,7 +83,7 @@
             // Draw particle
             ctx.beginPath();
             ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2);
-            ctx.fillStyle = THEME_COLOR;
+            ctx.fillStyle = themeColor;
             ctx.fill();
 
             // Connect nearby particles
@@ -96,7 +96,7 @@
                     ctx.beginPath();
                     ctx.moveTo(p.x, p.y);
                     ctx.lineTo(p2.x, p2.y);
-                    ctx.strokeStyle = THEME_COLOR;
+                    ctx.strokeStyle = themeColor;
                     ctx.globalAlpha = 1 - dist / CONNECTION_DISTANCE;
                     ctx.lineWidth = 0.5;
                     ctx.stroke();
@@ -157,4 +157,8 @@
 
     resize();
     createParticles();
+
+    window.updateParticleColor = function (color) {
+        themeColor = color;
+    };
 })();

--- a/script.js
+++ b/script.js
@@ -2,7 +2,71 @@ document.addEventListener('DOMContentLoaded', function () {
     // initialize lucide icons
     lucide.createIcons();
 
-    // print shortcut opens resume PDF instead
+    // ── theme toggle ──
+    var themeToggle = document.querySelector('.theme-toggle');
+
+    function getTheme() {
+        return document.documentElement.getAttribute('data-theme') || 'dark';
+    }
+
+    function updateSkillIcons(theme) {
+        var swaps = {
+            'ollama': { dark: 'ffffff', light: '000000' },
+            'modelcontextprotocol': { dark: 'ffffff', light: '000000' },
+            'linux': { dark: 'ffffff', light: '000000' }
+        };
+        document.querySelectorAll('.skills .card').forEach(function (card) {
+            var img = card.querySelector('img.icon');
+            if (!img) return;
+            var src = img.getAttribute('src');
+            Object.keys(swaps).forEach(function (key) {
+                if (src.includes('/' + key)) {
+                    img.setAttribute('src', 'https://cdn.simpleicons.org/' + key + '/' + swaps[key][theme]);
+                    card.setAttribute('data-color', theme === 'light' ? '#000000' : '#ffffff');
+                }
+            });
+        });
+    }
+
+    function setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        if (window.updateParticleColor) {
+            window.updateParticleColor(theme === 'light' ? '#2558cc' : '#3572ff');
+        }
+        updateSkillIcons(theme);
+        lucide.createIcons();
+    }
+
+    themeToggle.addEventListener('click', function () {
+        setTheme(getTheme() === 'dark' ? 'light' : 'dark');
+    });
+
+    // respect OS theme changes (only if no explicit preference stored)
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function (e) {
+        if (!localStorage.getItem('theme')) {
+            setTheme(e.matches ? 'light' : 'dark');
+        }
+    });
+
+    // sync across tabs
+    window.addEventListener('storage', function (e) {
+        if (e.key === 'theme' && e.newValue) {
+            setTheme(e.newValue);
+        }
+    });
+
+    // apply initial icon state
+    updateSkillIcons(getTheme());
+
+    // remove no-transition class after first paint
+    requestAnimationFrame(function () {
+        requestAnimationFrame(function () {
+            document.documentElement.classList.remove('no-transition');
+        });
+    });
+
+    // ── print shortcut opens resume PDF ──
     window.addEventListener('keydown', function (e) {
         if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
             e.preventDefault();
@@ -10,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    // navbar sticky + scroll-up button
+    // ── navbar sticky + scroll-up button ──
     window.addEventListener('scroll', function () {
         var navbar = document.querySelector('.navbar');
         var scrollBtn = document.querySelector('.scroll-up-btn');
@@ -31,7 +95,7 @@ document.addEventListener('DOMContentLoaded', function () {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     });
 
-    // toggle menu/navbar script
+    // ── toggle menu/navbar ──
     var menuBtn = document.querySelector('.menu-btn');
     var menu = document.querySelector('.navbar .menu');
 
@@ -57,7 +121,7 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
-    // typing animation script
+    // ── typing animations ──
     new Typed(".typing", {
         strings: ["I'm a Software Engineer."],
         typeSpeed: 100,
@@ -77,7 +141,7 @@ document.addEventListener('DOMContentLoaded', function () {
         loop: true
     });
 
-    // projects carousel (Swiper)
+    // ── projects carousel (Swiper) ──
     new Swiper('.carousel', {
         slidesPerView: 1,
         spaceBetween: 12,
@@ -100,24 +164,26 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    // skill icon hover: scale + brand color glow
+    // ── skill card hover: scale + brand color glow ──
     var skillCards = document.querySelectorAll('.skills .skills-content .card');
 
     skillCards.forEach(function (card) {
         var icon = card.querySelector('.icon');
-        var color = card.dataset.color || '#60a5fa';
 
         card.addEventListener('mouseenter', function () {
+            var color = card.dataset.color || '#60a5fa';
             icon.style.transform = 'scale(1.2)';
             card.style.borderColor = color + '60';
             card.style.boxShadow = '0 0 20px ' + color + ', 0 0 40px ' + color + '80';
         });
 
         card.addEventListener('mousemove', function (e) {
+            var color = card.dataset.color || '#60a5fa';
+            var alpha = getTheme() === 'light' ? '33' : '55';
             var rect = card.getBoundingClientRect();
             var x = e.clientX - rect.left;
             var y = e.clientY - rect.top;
-            card.style.background = 'radial-gradient(circle at ' + x + 'px ' + y + 'px, ' + color + '55 0%, transparent 65%)';
+            card.style.background = 'radial-gradient(circle at ' + x + 'px ' + y + 'px, ' + color + alpha + ' 0%, transparent 65%)';
         });
 
         card.addEventListener('mouseleave', function () {
@@ -128,10 +194,12 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
         card.addEventListener('focus', function () {
+            var color = card.dataset.color || '#60a5fa';
+            var alpha = getTheme() === 'light' ? '33' : '55';
             icon.style.transform = 'scale(1.2)';
             card.style.borderColor = color + '60';
             card.style.boxShadow = '0 0 20px ' + color + ', 0 0 40px ' + color + '80';
-            card.style.background = 'radial-gradient(circle at 50% 50%, ' + color + '55 0%, transparent 65%)';
+            card.style.background = 'radial-gradient(circle at 50% 50%, ' + color + alpha + ' 0%, transparent 65%)';
         });
 
         card.addEventListener('blur', function () {
@@ -142,11 +210,11 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
-    // degree card mouse glow
+    // ── degree card mouse glow ──
     var degreeCard = document.querySelector('.education .educ-content .degree');
-    var degreeColor = '#3572ff';
 
     degreeCard.addEventListener('mousemove', function (e) {
+        var degreeColor = getTheme() === 'light' ? '#2558cc' : '#3572ff';
         var rect = degreeCard.getBoundingClientRect();
         var x = e.clientX - rect.left;
         var y = e.clientY - rect.top;
@@ -159,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function () {
         degreeCard.style.borderColor = '';
     });
 
-    // scroll reveal
+    // ── scroll reveal ──
     var revealElements = document.querySelectorAll('.reveal');
     var observer = new IntersectionObserver(function (entries) {
         entries.forEach(function (entry) {

--- a/style.css
+++ b/style.css
@@ -29,6 +29,74 @@
     --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.3);
 }
 
+/* ── light mode overrides ── */
+[data-theme="light"] {
+    --color-theme: #2558cc;
+    --color-theme-glow: rgba(37, 88, 204, 0.2);
+    --color-accent: #1d4ed8;
+    --gradient-theme: linear-gradient(135deg, #2558cc, #1d4ed8);
+
+    --bg-primary: #f5f5fa;
+    --bg-card: rgba(0, 0, 0, 0.03);
+    --bg-glass: rgba(255, 255, 255, 0.7);
+    --bg-glass-hover: rgba(255, 255, 255, 0.9);
+
+    --glass-blur: blur(16px) saturate(1.1);
+    --glass-blur-heavy: blur(24px) saturate(1.2);
+
+    --text-primary: #1a1a2e;
+    --text-secondary: #555580;
+    --text-muted: #8888a8;
+
+    --border-glass: rgba(0, 0, 0, 0.1);
+    --border-hover: rgba(37, 88, 204, 0.3);
+
+    --shadow-glow: 0 0 40px rgba(37, 88, 204, 0.06);
+    --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .navbar .logo a { color: #1a1a2e; }
+[data-theme="light"] .navbar .menu li a:hover { color: #1a1a2e; }
+[data-theme="light"] .menu-btn { color: #1a1a2e; }
+[data-theme="light"] .menu-btn svg { stroke: #1a1a2e; }
+
+[data-theme="light"] .navbar.sticky {
+    background: rgba(245, 245, 250, 0.8);
+}
+
+[data-theme="light"] .home { color: #1a1a2e; }
+
+[data-theme="light"] .home .home-content .text-2 {
+    background: linear-gradient(135deg, #1a1a2e 40%, var(--color-accent));
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
+[data-theme="light"] .education .educ-content .card:hover svg,
+[data-theme="light"] .education .educ-content .card:focus svg {
+    stroke: var(--color-theme);
+}
+
+[data-theme="light"] section::after {
+    opacity: 0.04;
+}
+
+[data-theme="light"] .about .about-content .right a.factset:hover,
+[data-theme="light"] .about .about-content .right a.uofm:hover {
+    color: #1a1a2e;
+}
+
+[data-theme="light"] .contact .contact-content .info .sub-title a:hover { color: #1a1a2e; }
+[data-theme="light"] footer span a:hover { color: #1a1a2e; }
+
+/* ── no-transition on load ── */
+html.no-transition,
+html.no-transition *,
+html.no-transition *::before,
+html.no-transition *::after {
+    transition: none !important;
+}
+
 ::selection {
     background: var(--color-theme);
     color: white;
@@ -96,6 +164,36 @@ html {
     padding: 0 24px;
 }
 
+/* ── theme toggle ── */
+.theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    margin-left: 16px;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+    transform: scale(1.1);
+}
+
+.theme-toggle svg {
+    width: 28px;
+    height: 28px;
+    stroke: var(--text-primary);
+}
+
+/* sun shown in dark (click for light), moon shown in light (click for dark) */
+.theme-icon-light { display: block; }
+.theme-icon-dark { display: none; }
+[data-theme="light"] .theme-icon-light { display: none; }
+[data-theme="light"] .theme-icon-dark { display: block; }
+
 .navbar .logo a {
     color: #fff;
     font-size: 32px;
@@ -132,9 +230,11 @@ html {
 
 .menu-btn {
     color: #fff;
-    font-size: 23px;
     cursor: pointer;
     display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 6px;
 }
 
 .menu-btn svg {
@@ -1075,7 +1175,7 @@ footer span a:hover {
 
 @media (max-width: 947px) {
     .menu-btn {
-        display: block;
+        display: flex;
         z-index: 999;
     }
 
@@ -1106,6 +1206,11 @@ footer span a:hover {
         margin: 20px 0;
         font-size: 24px;
         color: var(--text-primary);
+    }
+
+    .theme-toggle {
+        margin-left: auto;
+        margin-right: 12px;
     }
 
     .home .home-content .text-2 {
@@ -1436,5 +1541,12 @@ footer span a:hover {
 
     .projs .carousel .card .text {
         font-size: 16px;
+    }
+}
+
+/* ── light mode responsive overrides ── */
+@media (max-width: 947px) {
+    [data-theme="light"] .navbar .menu {
+        background: rgba(245, 245, 250, 0.95);
     }
 }


### PR DESCRIPTION
## Summary
- Sun/moon toggle in navbar with smooth theme switching
- Full light mode CSS variable overrides (backgrounds, text, borders, glass effects, shadows)
- FOUC prevention via blocking inline script before stylesheet
- Respects OS `prefers-color-scheme` on first visit, persists choice to localStorage
- Cross-tab sync via storage event listener
- Particle canvas and skill icon colors adapt to theme
- Reduced glow intensity in light mode for readability

## Test plan
- [ ] Toggle works on desktop and mobile
- [ ] No flash of wrong theme on page load
- [ ] Preference persists across page refreshes
- [ ] System preference detected on first visit (no stored preference)
- [ ] Skill icons (Ollama, MCP, Linux) swap white/black correctly
- [ ] Particle canvas uses appropriate color per theme
- [ ] Mobile menu background adapts to theme
- [ ] All text readable in both modes
- [ ] Cross-tab sync works (toggle in one tab, other tab updates)